### PR TITLE
Improvements and fixes to encrypt samples

### DIFF
--- a/src/common/common.c
+++ b/src/common/common.c
@@ -118,3 +118,22 @@ int bytes_to_new_hexstring(char *bytes, size_t bytes_len, unsigned char **hex_ar
 
     return 0;
 }
+
+/**
+ * Prints a byte array as a hex string.
+ * @param bytes
+ * @param bytes_len
+ * @return
+ */
+int print_bytes_as_hex(char *bytes, size_t bytes_len) {
+    if (!bytes || bytes_len < 1) {
+        return -1;
+    }
+
+    for (int i = 0; i < bytes_len; i++) {
+        printf("%02X", bytes[i]);
+    }
+    printf("\n");
+
+    return 0;
+}

--- a/src/common/common.h
+++ b/src/common/common.h
@@ -42,4 +42,6 @@ int get_pkcs_args(int argc, char **argv, struct pkcs_arguments *args);
 
 int bytes_to_new_hexstring(char *bytes, size_t bytes_len, unsigned char **hex);
 
+int print_bytes_as_hex(char *bytes, size_t bytes_len);
+
 #endif

--- a/src/encrypt/aes_ecb.c
+++ b/src/encrypt/aes_ecb.c
@@ -28,7 +28,7 @@ void aes_ecb_sample(CK_SESSION_HANDLE session) {
     // Generate a 256 bit AES key.
     CK_OBJECT_HANDLE aes_key;
     rv = generate_aes_key(session, 32, &aes_key);
-    if (rv != CKR_OK) {
+    if (CKR_OK != rv) {
         printf("AES key generation failed: %lu\n", rv);
         return;
     }
@@ -48,42 +48,36 @@ void aes_ecb_sample(CK_SESSION_HANDLE session) {
     //**********************************************************************************************
 
     rv = funcs->C_EncryptInit(session, &mech, aes_key);
-    if (rv != CKR_OK) {
+    if (CKR_OK != rv) {
         printf("Encryption Init failed: %lu\n", rv);
         return;
     }
 
     // Determine how much memory will be required to hold the ciphertext.
     rv = funcs->C_Encrypt(session, plaintext, plaintext_length, NULL, &ciphertext_length);
-    if (rv != CKR_OK) {
+    if (CKR_OK != rv) {
         printf("Encryption failed: %lu\n", rv);
         return;
     }
 
     // Allocate the required memory.
     CK_BYTE_PTR ciphertext = malloc(ciphertext_length);
-    if (NULL==ciphertext) {
+    if (NULL == ciphertext) {
         printf("Could not allocate memory for ciphertext\n");
         return;
     }
     memset(ciphertext, 0, ciphertext_length);
-    unsigned char *hex_array = NULL;
-    CK_BYTE_PTR decrypted_ciphertext = NULL;
 
-            // Encrypt the data.
+    // Encrypt the data.
     rv = funcs->C_Encrypt(session, plaintext, plaintext_length, ciphertext, &ciphertext_length);
-    if (rv != CKR_OK) {
+    if (CKR_OK != rv) {
         printf("Encryption failed: %lu\n", rv);
         goto done;
     }
 
     // Print just the ciphertext in hex format
-    bytes_to_new_hexstring(ciphertext, ciphertext_length, &hex_array);
-    if (!hex_array) {
-        printf("Could not allocate memory for hex array\n");
-        goto done;
-    }
-    printf("Ciphertext: %s\n", hex_array);
+    printf("Ciphertext: ");
+    print_bytes_as_hex(ciphertext, ciphertext_length);
     printf("Ciphertext length: %lu\n", ciphertext_length);
 
     //**********************************************************************************************
@@ -91,45 +85,43 @@ void aes_ecb_sample(CK_SESSION_HANDLE session) {
     //********************************************************************************************** 
 
     rv = funcs->C_DecryptInit(session, &mech, aes_key);
-    if (rv != CKR_OK) {
+    if (CKR_OK != rv) {
         printf("Decryption Init failed: %lu\n", rv);
         return;
     }
 
     // Determine how much memory is required to hold the decrypted text.
+    CK_BYTE_PTR decrypted_ciphertext = NULL;
     CK_ULONG decrypted_ciphertext_length = 0;
     rv = funcs->C_Decrypt(session, ciphertext, ciphertext_length, NULL, &decrypted_ciphertext_length);
-    if (rv != CKR_OK) {
+    if (CKR_OK != rv) {
         printf("Decryption failed: %lu\n", rv);
         goto done;
     }
 
     // Allocate memory for the decrypted ciphertext.
     decrypted_ciphertext = malloc(decrypted_ciphertext_length);
-    if (NULL==decrypted_ciphertext) {
+    if (NULL == decrypted_ciphertext) {
         printf("Could not allocate memory for decrypted ciphertext\n");
         goto done;
     }
 
     // Decrypt the ciphertext.
     rv = funcs->C_Decrypt(session, ciphertext, ciphertext_length, decrypted_ciphertext, &decrypted_ciphertext_length);
-    if (CKR_OK!=rv) {
+    if (CKR_OK != rv) {
         printf("Decryption failed: %lu\n", rv);
         goto done;
     }
 
-    printf("Decrypted text: %s\n", decrypted_ciphertext);
+    printf("Decrypted ciphertext: %.*s\n", (int)decrypted_ciphertext_length, decrypted_ciphertext);
+    printf("Decrypted ciphertext length: %lu\n", decrypted_ciphertext_length);
 
 done:
-    if (NULL!=decrypted_ciphertext) {
+    if (NULL != decrypted_ciphertext) {
         free(decrypted_ciphertext);
     }
 
-    if (NULL!=hex_array) {
-        free(hex_array);
-    }
-
-    if (NULL!=ciphertext) {
+    if (NULL != ciphertext) {
         free(ciphertext);
     }
 }


### PR DESCRIPTION
*Description of changes:*
1. Corrected IV in aes_cbc.c
2. Print bytes directly as hex strings. Previously, non-null terminated hex strings were not printing correctly.
3. Made all if statements to have constant on the left hand side

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
