### PR TITLE
Add AES-GCM Key Wrapping example

### DIFF
--- a/src/wrapping/CMakeLists.txt
+++ b/src/wrapping/CMakeLists.txt
@@ -3,7 +3,7 @@ project(wrapping)
 
 find_library(cloudhsmpkcs11 STATIC)
 
-add_executable(wrapping aes_wrapping.c rsa_wrapping.c wrap.c wrap.h)
+add_executable(wrapping aes_wrapping_common.c aes_wrapping.c aes_gcm_wrapping.c rsa_wrapping.c wrap.c wrap.h)
 target_link_libraries(wrapping cloudhsmpkcs11 ssl crypto)
 
 add_test(wrapping wrapping --pin ${HSM_USER}:${HSM_PASSWORD})

--- a/src/wrapping/aes_wrapping_common.c
+++ b/src/wrapping/aes_wrapping_common.c
@@ -1,0 +1,75 @@
+#include <stdio.h>
+#include <stdint.h>
+#include <stdlib.h>
+#include <string.h>
+#include <common.h>
+
+/**
+ * Generate an AES key that can be used to wrap and unwrap other keys.
+ * The wrapping key must be a token key. We have to manually clean it
+ * up at the end of this sample.
+ * @param session
+ * @param key_length_bytes
+ * @param key
+ * @return
+ */
+CK_RV generate_wrapping_key(CK_SESSION_HANDLE session,
+                            CK_ULONG key_length_bytes,
+                            CK_OBJECT_HANDLE_PTR key) {
+    CK_RV rv;
+    CK_MECHANISM mech;
+
+    mech.mechanism = CKM_AES_KEY_GEN;
+    mech.ulParameterLen = 0;
+    mech.pParameter = NULL;
+
+    CK_ATTRIBUTE template[] = {
+            {CKA_TOKEN,     &true_val,             sizeof(CK_BBOOL)},
+            {CKA_WRAP,      &true_val,             sizeof(CK_BBOOL)},
+            {CKA_UNWRAP,    &true_val,             sizeof(CK_BBOOL)},
+            {CKA_ENCRYPT,   &false_val,            sizeof(CK_BBOOL)},
+            {CKA_DECRYPT,   &false_val,            sizeof(CK_BBOOL)},
+            {CKA_VALUE_LEN, &key_length_bytes, sizeof(key_length_bytes)}
+    };
+
+    rv = funcs->C_GenerateKey(session, &mech, template, sizeof(template) / sizeof(CK_ATTRIBUTE), key);
+    return rv;
+}
+
+/**
+ * Generate an RSA key pair suitable for signing data and verifying signatures.
+ * @param session Valid PKCS11 session.
+ * @param key_length_bits Bit size of key. Supported sizes are here: https://docs.aws.amazon.com/cloudhsm/latest/userguide/pkcs11-key-types.html
+ * @param public_key Pointer where the public key handle will be stored.
+ * @param private_key Pointer where the private key handle will be stored.
+ * @return CK_RV Value returned by the PKCS#11 library. This will indicate success or failure.
+ */
+CK_RV generate_rsa_keypair(CK_SESSION_HANDLE session,
+                           CK_ULONG key_length_bits,
+                           CK_OBJECT_HANDLE_PTR public_key,
+                           CK_OBJECT_HANDLE_PTR private_key) {
+    CK_RV rv;
+    CK_MECHANISM mech = {CKM_RSA_X9_31_KEY_PAIR_GEN, NULL, 0};
+    CK_BYTE public_exponent[] = {0x01, 0x00, 0x01};
+
+    CK_ATTRIBUTE public_key_template[] = {
+            {CKA_TOKEN,           &false_val,           sizeof(CK_BBOOL)},
+            {CKA_VERIFY,          &true_val,            sizeof(CK_BBOOL)},
+            {CKA_MODULUS_BITS,    &key_length_bits, sizeof(CK_ULONG)},
+            {CKA_PUBLIC_EXPONENT, &public_exponent, sizeof(public_exponent)},
+    };
+
+    CK_ATTRIBUTE private_key_template[] = {
+            {CKA_TOKEN,       &false_val, sizeof(CK_BBOOL)},
+            {CKA_SIGN,        &true_val,  sizeof(CK_BBOOL)},
+            {CKA_EXTRACTABLE, &true_val,  sizeof(CK_BBOOL)}
+    };
+
+    rv = funcs->C_GenerateKeyPair(session,
+                                  &mech,
+                                  public_key_template, sizeof(public_key_template) / sizeof(CK_ATTRIBUTE),
+                                  private_key_template, sizeof(private_key_template) / sizeof(CK_ATTRIBUTE),
+                                  public_key,
+                                  private_key);
+    return rv;
+}

--- a/src/wrapping/aes_wrapping_common.h
+++ b/src/wrapping/aes_wrapping_common.h
@@ -1,0 +1,13 @@
+#ifndef _AES_WRAPPING_COMMON_H_
+#define _AES_WRAPPING_COMMON_H_
+
+CK_RV generate_wrapping_key(CK_SESSION_HANDLE session,
+                            CK_ULONG key_length_bytes,
+                            CK_OBJECT_HANDLE_PTR key);
+
+CK_RV generate_rsa_keypair(CK_SESSION_HANDLE session,
+                           CK_ULONG key_length_bits,
+                           CK_OBJECT_HANDLE_PTR public_key,
+                           CK_OBJECT_HANDLE_PTR private_key);
+
+#endif  /* _AES_WRAPPING_COMMON_H_ */

--- a/src/wrapping/wrap.c
+++ b/src/wrapping/wrap.c
@@ -57,6 +57,12 @@ int main(int argc, char **argv) {
         return rc;
     }
 
+    printf("Running AES-GCM wrap...\n");
+    rc = aes_gcm_wrap(session);
+    if (CKR_OK != rc) {
+        return rc;
+    }
+
     pkcs11_finalize_session(session);
     return rc;
 }

--- a/src/wrapping/wrap.h
+++ b/src/wrapping/wrap.h
@@ -26,6 +26,7 @@
 int rsa_aes_wrap(CK_SESSION_HANDLE session);
 int rsa_oaep_wrap(CK_SESSION_HANDLE session);
 int aes_wrap(CK_SESSION_HANDLE session);
+int aes_gcm_wrap(CK_SESSION_HANDLE session);
 CK_RV rsa_aes_unwrap_key(
         CK_SESSION_HANDLE session,
         CK_OBJECT_HANDLE wrapping_key,


### PR DESCRIPTION
Add an example of using AES-GCM for key wrapping. This is basically the same test as AES Key Wrapping, but using AES-GCM instead.