### PR TITLE
Fixed an issue where we were printing a non-null-terminated string in an unbounded manner

### DIFF
--- a/src/encrypt/aes_ctr.c
+++ b/src/encrypt/aes_ctr.c
@@ -127,7 +127,8 @@ CK_RV aes_ctr_sample(CK_SESSION_HANDLE session) {
         goto done;
     }
 
-    printf("Decrypted text: %s\n", decrypted_ciphertext);
+    printf("Decrypted ciphertext: %.*s\n", (int)decrypted_ciphertext_length, decrypted_ciphertext);
+    printf("Decrypted ciphertext length: %lu\n", decrypted_ciphertext_length);
 
 done:
     if (NULL != decrypted_ciphertext) {


### PR DESCRIPTION
*Issue #, if available:* N/A

*Description of changes:* Updated a print statement to have a bounded number of bytes

Tested by running it on a local test instance:

```
+ VALGRIND='valgrind --log-file=/root/baldr-client-tests/aws-cloudhsm-pkcs11-examples/build/P11-Samples-Valgrind-Report-%p.txt --trace-children=yes --child-silent-after-fork=yes --leak-check=full --track-origins=yes --error-exitcode=128'
+ make test
Running tests...
Test project /root/baldr-client-tests/aws-cloudhsm-pkcs11-examples/build
      Start  1: digest
 1/16 Test  #1: digest ...........................   Passed    0.14 sec
      Start  2: generate
 2/16 Test  #2: generate .........................   Passed    0.28 sec
      Start  3: sign
 3/16 Test  #3: sign .............................   Passed    0.37 sec
      Start  4: aes_cbc
 4/16 Test  #4: aes_cbc ..........................   Passed    1.05 sec
      Start  5: aes_ecb
 5/16 Test  #5: aes_ecb ..........................   Passed    0.14 sec
      Start  6: aes_gcm
 6/16 Test  #6: aes_gcm ..........................   Passed    0.19 sec
      Start  7: aes_ctr
 7/16 Test  #7: aes_ctr ..........................   Passed    0.24 sec
      Start  8: des_ecb
 8/16 Test  #8: des_ecb ..........................   Passed    0.27 sec
      Start  9: wrapping
 9/16 Test  #9: wrapping .........................   Passed    1.73 sec
      Start 10: wrap_with_template
10/16 Test #10: wrap_with_template ...............   Passed    0.84 sec
      Start 11: unwrap_with_template
11/16 Test #11: unwrap_with_template .............   Passed    0.63 sec
      Start 12: hsm_info
12/16 Test #12: hsm_info .........................   Passed    0.29 sec
      Start 13: find_objects
13/16 Test #13: find_objects .....................   Passed    0.45 sec
      Start 14: ecdh
14/16 Test #14: ecdh .............................   Passed    1.39 sec
      Start 15: counter_kdf
15/16 Test #15: counter_kdf ......................   Passed    0.16 sec
      Start 16: hmac_kdf
16/16 Test #16: hmac_kdf .........................   Passed    0.21 sec

100% tests passed, 0 tests failed out of 16

Total Test time (real) =   8.40 sec
+ echo '-crypto-test-result RunPublicPKCS11Samples SUCCEEDED'

```


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
