### PR TITLE
Clear ulIvBits in AES-GCM Mechanism parameters

### DIFF
--- a/src/encrypt/aes_gcm.c
+++ b/src/encrypt/aes_gcm.c
@@ -60,6 +60,7 @@ CK_RV aes_gcm_sample(CK_SESSION_HANDLE session) {
     // Setup the mechanism with the IV location and AAD information.
     params.pIv = iv;
     params.ulIvLen = AES_GCM_IV_SIZE;
+    params.ulIvBits = 0;
     params.pAAD = aad;
     params.ulAADLen = aad_length;
     params.ulTagBits = AES_GCM_TAG_SIZE * 8;


### PR DESCRIPTION
PKCS11 AES-GCM Mechanism Parameters accept both ulIvLen and ulIvBits. We should be clearing out ulIvBits otherwise it contains unitialized data.

Test Run:

src/encrypt/aes_gcm  --library /opt/cloudhsm/lib/libcloudhsm_pkcs11.so --pin xxxx:yyyy

Encrypt/Decrypt with AES GCM
Plaintext: plaintext payload to encrypt
Plaintext length: 28
AAD: plaintext aad
AAD length: 13
IV: C3A907709758BBFB8B8FE87B
IV length: 12
Ciphertext: F8D5230E5F899AE60D835363276475263628FD3A9675D45C049BBA23
Ciphertext length: 28
Tag: 288126602324512CCC4162751522AAC3
Tag length: 16
Decrypted ciphertext: plaintext payload to encrypt
Decrypted ciphertext length: 28
