### PR TITLE
Fix compilation failure in attributes.c

### DIFF
--- a/src/attributes/attributes.c
+++ b/src/attributes/attributes.c
@@ -261,8 +261,7 @@ CK_RV attributes_output_all(
     uint8_t* attr_avail = calloc(attributes_types_len, sizeof(uint8_t));
     if (NULL == attr_avail) {
         fprintf(f, "ERROR: failed to allocate memory\n");
-        rv = CKR_HOST_MEMORY;
-        break;
+        return CKR_HOST_MEMORY;
     }
 
     size_t i = (size_t)0;


### PR DESCRIPTION
*Description of changes:*

Compilation of attributes artifact was failing due to a syntax error:
```
/home/ec2-user/aws-cloudhsm-pkcs11-examples/src/attributes/attributes.c: In function ‘attributes_output_all’:
/home/ec2-user/aws-cloudhsm-pkcs11-examples/src/attributes/attributes.c:264:9: error: ‘rv’ undeclared (first use in this function)
         rv = CKR_HOST_MEMORY;
         ^~
/home/ec2-user/aws-cloudhsm-pkcs11-examples/src/attributes/attributes.c:264:9: note: each undeclared identifier is reported only once for each function it appears in
/home/ec2-user/aws-cloudhsm-pkcs11-examples/src/attributes/attributes.c:265:9: error: break statement not within loop or switch
         break;
         ^~~~~
make[2]: *** [src/attributes/CMakeFiles/attributes.dir/attributes.c.o] Error 1
make[1]: *** [src/attributes/CMakeFiles/attributes.dir/all] Error 2
```
The function expected to be inside a `for` loop, but was not. Updated to directly `return CKR_HOST_MEMORY` instead. 

After fix:
```
$ make test
Running tests...
Test project /home/ec2-user/aws-cloudhsm-pkcs11-examples/build
      Start  1: digest
 1/23 Test  #1: digest ...........................   Passed    0.06 sec
      Start  2: aes_generate
 2/23 Test  #2: aes_generate .....................   Passed    0.14 sec
      Start  3: rsa_generate
 3/23 Test  #3: rsa_generate .....................   Passed    0.14 sec
      Start  4: ec_generate
 4/23 Test  #4: ec_generate ......................   Passed    0.21 sec
      Start  5: sign
 5/23 Test  #5: sign .............................   Passed    0.19 sec
      Start  6: multi_part_sign
 6/23 Test  #6: multi_part_sign ..................   Passed    0.92 sec
      Start  7: aes_cbc
 7/23 Test  #7: aes_cbc ..........................   Passed    0.95 sec
      Start  8: aes_ecb
 8/23 Test  #8: aes_ecb ..........................   Passed    0.14 sec
      Start  9: aes_gcm
 9/23 Test  #9: aes_gcm ..........................   Passed    0.14 sec
      Start 10: aes_ctr
10/23 Test #10: aes_ctr ..........................   Passed    0.14 sec
      Start 11: des_ecb
11/23 Test #11: des_ecb ..........................   Passed    0.14 sec
      Start 12: aes_gcm_wrapping
12/23 Test #12: aes_gcm_wrapping .................   Passed    0.17 sec
      Start 13: aes_no_padding_wrapping
13/23 Test #13: aes_no_padding_wrapping ..........   Passed    0.19 sec
      Start 14: aes_zero_padding_wrapping
14/23 Test #14: aes_zero_padding_wrapping ........   Passed    0.19 sec
      Start 15: aes_wrapping
15/23 Test #15: aes_wrapping .....................   Passed    0.19 sec
      Start 16: rsa_wrapping
16/23 Test #16: rsa_wrapping .....................   Passed    0.31 sec
      Start 17: wrap_with_template
17/23 Test #17: wrap_with_template ...............   Passed    0.27 sec
      Start 18: unwrap_with_template
18/23 Test #18: unwrap_with_template .............   Passed    0.24 sec
      Start 19: mechanism_info
19/23 Test #19: mechanism_info ...................   Passed    0.16 sec
      Start 20: find_objects
20/23 Test #20: find_objects .....................   Passed    0.19 sec
      Start 21: ecdh
21/23 Test #21: ecdh .............................   Passed    0.57 sec
      Start 22: hmac_kdf
22/23 Test #22: hmac_kdf .........................   Passed    0.14 sec
      Start 23: generate_random
23/23 Test #23: generate_random ..................   Passed    0.13 sec

100% tests passed, 0 tests failed out of 23

Total Test time (real) =   5.89 sec
```

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
