### PR TITLE
Clear ulIvBits in AES-GCM Mechanism parameters when doing ECDH

### DIFF
--- a/src/derivation/ecdh.c
+++ b/src/derivation/ecdh.c
@@ -155,6 +155,7 @@ CK_RV aes_gcm_sample(CK_SESSION_HANDLE session, CK_OBJECT_HANDLE_PTR aes_key) {
     // Setup the mechanism with the IV location and AAD information.
     params.pIv = iv;
     params.ulIvLen = AES_GCM_IV_SIZE;
+    params.ulIvBits = 0;
     params.pAAD = aad;
     params.ulAADLen = aad_length;
     params.ulTagBits = AES_GCM_TAG_SIZE * 8;


### PR DESCRIPTION
*Issue #, if available:*

Clear ulIvBits in AES-GCM Mechanism parameters when doing ECDH


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
