### PR TITLE
Pass strings by value instead of address in HMAC KDF sample

### DIFF
--- a/src/derivation/hmac_kdf.c
+++ b/src/derivation/hmac_kdf.c
@@ -125,8 +125,8 @@ CK_RV hmac_kdf_sample(CK_SESSION_HANDLE session) {
     CK_PRF_DATA_PARAM kdf_data_params[] = {
         {SP800_108_COUNTER_FORMAT,    &counter_format,     sizeof(CK_SP800_108_COUNTER_FORMAT)},
         {SP800_108_DKM_FORMAT,        &dkm_format,         sizeof(CK_SP800_108_DKM_LENGTH_FORMAT)},
-        {SP800_108_PRF_LABEL,         &label,              sizeof(label)},
-        {SP800_108_PRF_CONTEXT,       &context,            sizeof(context)}
+        {SP800_108_PRF_LABEL,         label,               sizeof(label)},
+        {SP800_108_PRF_CONTEXT,       context,             sizeof(context)}
     };
 
     CK_SP800_108_KDF_PARAMS kdf_params;    


### PR DESCRIPTION
Instead of passing labels in PKCS#11 samples by their addresses, pass the labels by value

hmac sample:
```
ubuntu@ip-172-31-0-130:~/aws-cloudhsm-pkcs11-examples/build$ ./src/derivation/hmac_kdf --pin cu1:password 2>/dev/null
Key derivation using HMAC KDF in Counter mode. Defined in NIST SP 800-108.
Generated base AES key of size 32 bytes. Handle: 4611686018427387905
Derived AES key of size 32 bytes. Handle: 4611686018427387906
ubuntu@ip-172-31-0-130:~/aws-cloudhsm-pkcs11-examples/build$ echo $?
0
```

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
