### PR TITLE
Update source to build on Windows

### DIFF
--- a/include/pkcs11/v2.40/cloudhsm_pkcs11_vendor_defs.h
+++ b/include/pkcs11/v2.40/cloudhsm_pkcs11_vendor_defs.h
@@ -30,6 +30,10 @@
 
 #include "pkcs11.h"
 
+#ifdef _WIN32
+#pragma pack(push, cloudhsm_pkcs11_vendor_defines, 1)
+#endif
+
 #define CKM_DES3_NIST_WRAP             (CKM_VENDOR_DEFINED | 0x00008000UL)
 #define CKM_CLOUDHSM_AES_GCM           (CKM_VENDOR_DEFINED | CKM_AES_GCM)
 
@@ -95,5 +99,9 @@ typedef struct CK_SP800_108_KDF_PARAMS {
  * {SP800_108_PRF_LABEL, (pointer to buff containing prf label), buffer length}
  * and so on.
  */
+
+#ifdef _WIN32
+#pragma pack(pop, cloudhsm_pkcs11_vendor_defines)
+#endif
 
 #endif /* _CLOUDHSM_PKCS11_VENDOR_DEFS_H_ */

--- a/src/digest/multi_part_digest.c
+++ b/src/digest/multi_part_digest.c
@@ -75,7 +75,7 @@ int main(int argc, char **argv) {
     CK_SESSION_HANDLE session;
     int rc = EXIT_FAILURE;
 
-    struct pkcs_arguments args = {};
+    struct pkcs_arguments args = {0};
     if (get_pkcs_args(argc, argv, &args) < 0) {
         return rc;
     }
@@ -91,7 +91,7 @@ int main(int argc, char **argv) {
     }
 
     CK_BYTE_PTR data = "Message requiring a digest";
-    CK_ULONG data_length = strlen(data);
+    CK_ULONG data_length = (CK_ULONG) strlen(data);
     CK_BYTE_PTR digest = NULL;
     CK_ULONG digest_length = 0;
 

--- a/src/generate/aes_generate.c
+++ b/src/generate/aes_generate.c
@@ -17,7 +17,6 @@
 #include <stdio.h>
 #include <string.h>
 #include <stdlib.h>
-#include <dlfcn.h>
 
 #include <common.h>
 
@@ -48,7 +47,7 @@ int main(int argc, char **argv) {
     CK_RV rv;
     CK_SESSION_HANDLE session;
 
-    struct pkcs_arguments args = {};
+    struct pkcs_arguments args = {0};
     if (get_pkcs_args(argc, argv, &args) < 0) {
         return 1;
     }

--- a/src/generate/rsa_generate.c
+++ b/src/generate/rsa_generate.c
@@ -17,7 +17,6 @@
 #include <stdio.h>
 #include <string.h>
 #include <stdlib.h>
-#include <dlfcn.h>
 
 #include <common.h>
 
@@ -63,7 +62,7 @@ int main(int argc, char **argv) {
     CK_RV rv;
     CK_SESSION_HANDLE session;
 
-    struct pkcs_arguments args = {};
+    struct pkcs_arguments args = {0};
     if (get_pkcs_args(argc, argv, &args) < 0) {
         return 1;
     }

--- a/src/sign/ec_sign.c
+++ b/src/sign/ec_sign.c
@@ -116,7 +116,7 @@ CK_RV ec_sign_verify(CK_SESSION_HANDLE session) {
 CK_RV multi_part_ec_sign_verify(CK_SESSION_HANDLE session) {
     CK_RV rv;
     CK_BYTE_PTR data = "Some data to sign";
-    CK_ULONG data_length = strlen(data);
+    CK_ULONG data_length = (CK_ULONG) strlen(data);
 
     CK_BYTE signature[MAX_SIGNATURE_LENGTH];
     CK_ULONG signature_length = MAX_SIGNATURE_LENGTH;

--- a/src/sign/multi_part_sign.c
+++ b/src/sign/multi_part_sign.c
@@ -20,7 +20,7 @@ int main(int argc, char **argv) {
     CK_RV rv;
     CK_SESSION_HANDLE session;
 
-    struct pkcs_arguments args = {};
+    struct pkcs_arguments args = {0};
     if (get_pkcs_args(argc, argv, &args) < 0) {
         return 1;
     }

--- a/src/sign/rsa_sign.c
+++ b/src/sign/rsa_sign.c
@@ -117,7 +117,7 @@ CK_RV multi_part_rsa_sign_verify(CK_SESSION_HANDLE session) {
     }
 
     CK_BYTE_PTR data = "Here is some data to sign";
-    CK_ULONG data_length = strlen(data);
+    CK_ULONG data_length = (CK_ULONG) strlen(data);
 
     CK_BYTE signature[MAX_SIGNATURE_LENGTH];
     CK_ULONG signature_length = MAX_SIGNATURE_LENGTH;


### PR DESCRIPTION
## Summary
Removed unnecessary includes, explicitly zero-fill structures, add #pragma pack
to the CloudHSM vendor defined include file so that the SDK can properly align
structures for Linux and Windows.

## Testing
**Note** Testing using SDK 5.x, so unwrap_with_template and ecdh are not yet supported samples

Linux
```
ubuntu@ip-172-31-13-165:~/aws-cloudhsm-pkcs11-examples/build$ make test
Running tests...
Test project /home/ubuntu/aws-cloudhsm-pkcs11-examples/build
      Start  1: digest
 1/23 Test  #1: digest ...........................   Passed    0.20 sec
      Start  2: aes_generate
 2/23 Test  #2: aes_generate .....................   Passed    0.29 sec
      Start  3: rsa_generate
 3/23 Test  #3: rsa_generate .....................   Passed    0.30 sec
      Start  4: ec_generate
 4/23 Test  #4: ec_generate ......................   Passed    0.40 sec
      Start  5: sign
 5/23 Test  #5: sign .............................   Passed    0.42 sec
      Start  6: multi_part_sign
 6/23 Test  #6: multi_part_sign ..................   Passed    0.44 sec
      Start  7: aes_cbc
 7/23 Test  #7: aes_cbc ..........................   Passed    0.25 sec
      Start  8: aes_ecb
 8/23 Test  #8: aes_ecb ..........................   Passed    0.30 sec
      Start  9: aes_gcm
 9/23 Test  #9: aes_gcm ..........................   Passed    0.29 sec
      Start 10: aes_ctr
10/23 Test #10: aes_ctr ..........................   Passed    0.25 sec
      Start 11: des_ecb
11/23 Test #11: des_ecb ..........................   Passed    0.25 sec
      Start 12: aes_gcm_wrapping
12/23 Test #12: aes_gcm_wrapping .................   Passed    0.51 sec
      Start 13: aes_no_padding_wrapping
13/23 Test #13: aes_no_padding_wrapping ..........   Passed    0.42 sec
      Start 14: aes_zero_padding_wrapping
14/23 Test #14: aes_zero_padding_wrapping ........   Passed    0.48 sec
      Start 15: aes_wrapping
15/23 Test #15: aes_wrapping .....................   Passed    0.50 sec
      Start 16: rsa_wrapping
16/23 Test #16: rsa_wrapping .....................   Passed    0.94 sec
      Start 17: wrap_with_template
17/23 Test #17: wrap_with_template ...............   Passed    0.46 sec
      Start 18: unwrap_with_template
18/23 Test #18: unwrap_with_template .............***Failed    0.25 sec
      Start 19: mechanism_info
19/23 Test #19: mechanism_info ...................   Passed    0.21 sec
      Start 20: find_objects
20/23 Test #20: find_objects .....................   Passed    0.41 sec
      Start 21: ecdh
21/23 Test #21: ecdh .............................***Failed    0.27 sec
      Start 22: hmac_kdf
22/23 Test #22: hmac_kdf .........................   Passed    0.34 sec
      Start 23: generate_random
23/23 Test #23: generate_random ..................   Passed    0.24 sec

91% tests passed, 2 tests failed out of 23

Total Test time (real) =   8.41 sec

# these are not currently supported with SDK 5.x
The following tests FAILED:
         18 - unwrap_with_template (Failed)
         21 - ecdh (Failed)
```

Windows
```
Build started...
1>------ Build started: Project: RUN_TESTS, Configuration: Debug x64 ------
1>Test project C:/Users/Administrator/Desktop/aws-cloudhsm-pkcs11-examples/build
1>      Start  1: digest
1> 1/23 Test  #1: digest ...........................   Passed    0.22 sec
1>      Start  2: aes_generate
1> 2/23 Test  #2: aes_generate .....................   Passed    0.23 sec
1>      Start  3: rsa_generate
1> 3/23 Test  #3: rsa_generate .....................   Passed    0.27 sec
1>      Start  4: ec_generate
1> 4/23 Test  #4: ec_generate ......................   Passed    0.36 sec
1>      Start  5: sign
1> 5/23 Test  #5: sign .............................   Passed    0.36 sec
1>      Start  6: multi_part_sign
1> 6/23 Test  #6: multi_part_sign ..................   Passed    0.35 sec
1>      Start  7: aes_cbc
1> 7/23 Test  #7: aes_cbc ..........................   Passed    0.26 sec
1>      Start  8: aes_ecb
1> 8/23 Test  #8: aes_ecb ..........................   Passed    0.20 sec
1>      Start  9: aes_gcm
1> 9/23 Test  #9: aes_gcm ..........................   Passed    0.25 sec
1>      Start 10: aes_ctr
1>10/23 Test #10: aes_ctr ..........................   Passed    0.21 sec
1>      Start 11: des_ecb
1>11/23 Test #11: des_ecb ..........................   Passed    0.24 sec
1>      Start 12: aes_gcm_wrapping
1>12/23 Test #12: aes_gcm_wrapping .................   Passed    0.40 sec
1>      Start 13: aes_no_padding_wrapping
1>13/23 Test #13: aes_no_padding_wrapping ..........   Passed    0.36 sec
1>      Start 14: aes_zero_padding_wrapping
1>14/23 Test #14: aes_zero_padding_wrapping ........   Passed    0.39 sec
1>      Start 15: aes_wrapping
1>15/23 Test #15: aes_wrapping .....................   Passed    0.40 sec
1>      Start 16: rsa_wrapping
1>16/23 Test #16: rsa_wrapping .....................   Passed    0.73 sec
1>      Start 17: wrap_with_template
1>17/23 Test #17: wrap_with_template ...............   Passed    0.50 sec
1>      Start 18: unwrap_with_template
1>18/23 Test #18: unwrap_with_template .............***Failed    0.21 sec
1>      Start 19: mechanism_info
1>19/23 Test #19: mechanism_info ...................   Passed    0.19 sec
1>      Start 20: find_objects
1>20/23 Test #20: find_objects .....................   Passed    0.40 sec
1>      Start 21: ecdh
1>21/23 Test #21: ecdh .............................***Failed    0.33 sec
1>      Start 22: hmac_kdf
1>22/23 Test #22: hmac_kdf .........................   Passed    0.29 sec
1>      Start 23: generate_random
1>23/23 Test #23: generate_random ..................   Passed    0.25 sec
1>
1>91% tests passed, 2 tests failed out of 23
1>
1>Total Test time (real) =   7.43 sec
1>
# these are not currently supported with SDK 5.x
1>The following tests FAILED:
1>     18 - unwrap_with_template (Failed)
1>     21 - ecdh (Failed)
```


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
