### PR TITLE
Add login_state and session_keys examples to show how p11 session state works

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -26,6 +26,7 @@ add_subdirectory(src/destroy)
 add_subdirectory(src/find_objects)
 add_subdirectory(src/derivation)
 add_subdirectory(src/generate_random)
+add_subdirectory(src/session)
 
 IF(LINUX)
   add_subdirectory(src/tools)

--- a/README.md
+++ b/README.md
@@ -27,8 +27,9 @@ sudo yum install -y cmake gcc gcc-c++ openssl-devel
 The examples are tested on Windows Server 2019 AMI. You will need to have the
 following installed:
 
-* (Microsoft C++ Build Tools)[https://visualstudio.microsoft.com/visual-cpp-build-tools/]
-* CMake 3.20
+* Visual Studio C++ CMake Tools for Windows - Available via the Visual Studio installer.
+* Visual Studio Build Tools 2019 - Available via the Visual Studio installer.
+* [CMake 3.x](https://cmake.org/download/)
 
 
 ### Building

--- a/src/encrypt/aes_cbc.c
+++ b/src/encrypt/aes_cbc.c
@@ -66,8 +66,8 @@ CK_RV aes_cbc_multipart_sample(CK_SESSION_HANDLE session) {
     }
 
     // We will stream several chunks of non block aligned random data to encrypt
-    size_t max_chunks = 4;
-    size_t chunk_idx = 0;
+    CK_ULONG max_chunks = 4;
+    CK_ULONG chunk_idx = 0;
 
     // The encrypted chunks will be stored in the ciphertext buffer
     CK_BYTE_PTR ciphertext = NULL;
@@ -76,11 +76,11 @@ CK_RV aes_cbc_multipart_sample(CK_SESSION_HANDLE session) {
 
     // We store the randomly generated plaintext as well, for visual comparison
     // 512 will hold enough for this sample.
-    CK_BYTE plaintext[512] = { };
+    CK_BYTE plaintext[512] = { 0 };
     CK_ULONG plaintext_size = CHUNK_SIZE * max_chunks;
 
     while(chunk_idx < max_chunks) {
-        CK_BYTE chunk[CHUNK_SIZE] = { };
+        CK_BYTE chunk[CHUNK_SIZE] = { 0 };
         get_random_data(chunk, CHUNK_SIZE);
         memcpy(&plaintext[chunk_idx * CHUNK_SIZE], chunk, CHUNK_SIZE);
         chunk_idx += 1;

--- a/src/session/CMakeLists.txt
+++ b/src/session/CMakeLists.txt
@@ -1,0 +1,12 @@
+cmake_minimum_required(VERSION 2.8)
+project(session)
+
+find_library(cloudhsmpkcs11 STATIC)
+
+add_executable(login_state login_state.c)
+add_executable(session_keys session_keys.c)
+target_link_libraries(login_state cloudhsmpkcs11)
+target_link_libraries(session_keys cloudhsmpkcs11)
+
+add_test(login_state login_state --pin ${HSM_USER}:${HSM_PASSWORD})
+add_test(session_keys login_state --pin ${HSM_USER}:${HSM_PASSWORD})

--- a/src/session/login_state.c
+++ b/src/session/login_state.c
@@ -1,0 +1,193 @@
+/*
+ * Copyright 2023 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+#include "common.h"
+#include <cloudhsm_pkcs11_vendor_defs.h>
+#include <cryptoki.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+
+CK_RV get_slot(CK_SLOT_ID *const);
+CK_RV open_sessions(CK_SLOT_ID, CK_SESSION_HANDLE *const,
+                    CK_SESSION_HANDLE *const, CK_SESSION_HANDLE *const);
+void display_session_state(const char *, CK_SESSION_HANDLE);
+void display_session_states(CK_SESSION_HANDLE, CK_SESSION_HANDLE,
+                            CK_SESSION_HANDLE);
+
+int main(int argc, char **argv) {
+  CK_SESSION_HANDLE session1 = CK_INVALID_HANDLE;
+  CK_SESSION_HANDLE session2 = CK_INVALID_HANDLE;
+  CK_SESSION_HANDLE session3 = CK_INVALID_HANDLE;
+  struct pkcs_arguments args = {0};
+
+  if (get_pkcs_args(argc, argv, &args) < 0) {
+    return EXIT_FAILURE;
+  }
+
+  if (pkcs11_initialize(args.library) != CKR_OK) {
+    return EXIT_FAILURE;
+  }
+
+  CK_SLOT_ID slot_id;
+  CK_RV rv = get_slot(&slot_id);
+  if (rv != CKR_OK) {
+    fprintf(stderr, "Failed to get first slot.\n");
+    return rv;
+  }
+
+  printf("Opening three sessions on the first slot.\n");
+  rv = open_sessions(slot_id, &session1, &session2, &session3);
+  if (CKR_OK != rv) {
+    return rv;
+  }
+  display_session_states(session1, session2, session3);
+
+  printf("Calling C_Login(session1, CU, pin, pin_length) on session 1 to "
+         "authenticate the slot.\n");
+  rv = funcs->C_Login(session1, CKU_USER, args.pin, (CK_ULONG)strlen(args.pin));
+  if (rv != CKR_OK) {
+    fprintf(stderr, "Failed to login on the slot via session1.\n");
+    return rv;
+  }
+  printf(
+      "Successfully logged in to the slot via session1.\nAll sessions on the "
+      "slot should now be authenticated with the single C_Login call,\n");
+  display_session_states(session1, session2, session3);
+
+  printf("Calling C_Login(session2, CU, pin, pin_length) on session 2 to "
+         "authenticate the slot.\n");
+  rv = funcs->C_Login(session2, CKU_USER, args.pin, (CK_ULONG)strlen(args.pin));
+  if (rv != CKR_USER_ALREADY_LOGGED_IN) {
+    fprintf(stderr, "Failure: did not get CKR_USER_ALREADY_LOGGED_IN on login "
+                    "on the slot via session2.\n");
+    return rv;
+  }
+  printf("Expected: Failed to log in on session2 because the slot is already "
+         "logged in.\n");
+  display_session_states(session1, session2, session3);
+
+  printf("Closing session1 via C_CloseSession(session1).\n");
+  rv = funcs->C_CloseSession(session1);
+  if (rv != CKR_OK) {
+    fprintf(stderr, "Failed to close session1.\n");
+    return rv;
+  }
+  session1 = CK_INVALID_HANDLE;
+  printf("Even with session1 closed, we still expect session2 and session3 to "
+         "be logged into the slot.\n");
+  display_session_states(session1, session2, session3);
+
+  printf("Calling C_Logout(session2) to log out of the slot.\n");
+  rv = funcs->C_Logout(session2);
+  if (rv != CKR_OK) {
+    fprintf(stderr, "Failed to log out of the slot via session2.\n");
+    return rv;
+  }
+  printf("Now we expect all open sessions on the slot to be logged out.\n");
+  display_session_states(session1, session2, session3);
+}
+
+CK_RV get_slot(CK_SLOT_ID *const slot_id) {
+  if (!slot_id) {
+    return CKR_ARGUMENTS_BAD;
+  }
+
+  CK_ULONG slot_count = 1;
+  CK_RV rv = funcs->C_GetSlotList(CK_TRUE, slot_id, &slot_count);
+  if (rv != CKR_OK) {
+    printf("C_GetSlotList failed with %lu", rv);
+    return rv;
+  } else {
+    printf("Got the first slot which corresponds to your CloudHSM cluster, "
+           "slot id = %lu\n",
+           *slot_id);
+  }
+
+  return rv;
+}
+
+CK_RV open_sessions(CK_SLOT_ID slot_id, CK_SESSION_HANDLE *const session1,
+                    CK_SESSION_HANDLE *const session2,
+                    CK_SESSION_HANDLE *const session3) {
+  // session 1
+  CK_RV rv = funcs->C_OpenSession(slot_id, CKF_SERIAL_SESSION | CKF_RW_SESSION,
+                                  NULL, NULL, session1);
+  if (rv != CKR_OK) {
+    fprintf(stderr, "Failed to open session1.\n");
+    return rv;
+  } else {
+    printf("Opened session1 on slot %lu\n", slot_id);
+  }
+
+  // session 2
+  rv = funcs->C_OpenSession(slot_id, CKF_SERIAL_SESSION | CKF_RW_SESSION, NULL,
+                            NULL, session2);
+  if (rv != CKR_OK) {
+    fprintf(stderr, "Failed to open session2.\n");
+    return rv;
+  } else {
+    printf("Opened session2 on slot %lu\n", slot_id);
+  }
+
+  // session 3
+  rv = funcs->C_OpenSession(slot_id, CKF_SERIAL_SESSION | CKF_RW_SESSION, NULL,
+                            NULL, session3);
+  if (rv != CKR_OK) {
+    fprintf(stderr, "Failed to open session3.\n");
+    return rv;
+  } else {
+    printf("Opened session3 on slot %lu\n", slot_id);
+  }
+
+  return CKR_OK;
+}
+
+void display_session_state(const char *name, CK_SESSION_HANDLE session_handle) {
+  char *state;
+
+  if (session_handle == CK_INVALID_HANDLE) {
+    state = "Disconnected from cluster";
+  } else {
+    CK_SESSION_INFO session_info;
+    funcs->C_GetSessionInfo(session_handle, &session_info);
+    if (session_info.state == CKS_RW_PUBLIC_SESSION) {
+      state = "Connected to cluster: Not logged in";
+    } else if (session_info.state == CKS_RW_USER_FUNCTIONS) {
+      state = "Connected to cluster: Authenticated";
+    } else {
+      state = "Connected to cluster: Unexpected state";
+    }
+  }
+
+  printf("%s: %s\n", name, state);
+}
+
+void display_session_states(CK_SESSION_HANDLE session1,
+                            CK_SESSION_HANDLE session2,
+                            CK_SESSION_HANDLE session3) {
+  // all sessions on the slot share the same state. Using session 3 to help
+  // illustrate this.
+  printf("\n");
+  display_session_state("Slot state", session3);
+  display_session_state("  * session1", session1);
+  display_session_state("  * session2", session2);
+  display_session_state("  * session3", session3);
+  printf("\n");
+}

--- a/src/session/session_keys.c
+++ b/src/session/session_keys.c
@@ -1,0 +1,224 @@
+/*
+ * Copyright 2023 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+#include "common.h"
+#include <cloudhsm_pkcs11_vendor_defs.h>
+#include <cryptoki.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+
+CK_RV open_sessions(CK_SESSION_HANDLE *const, CK_SESSION_HANDLE *const,
+                    CK_SESSION_HANDLE *const);
+CK_RV generate_ec_keypair(CK_SESSION_HANDLE session,
+                          CK_OBJECT_HANDLE_PTR public_key,
+                          CK_OBJECT_HANDLE_PTR private_key);
+CK_RV sign_hello_world(CK_SESSION_HANDLE session, CK_OBJECT_HANDLE key,
+                       CK_BYTE *const signature, CK_ULONG_PTR signature_length);
+CK_RV verify_hello_world(CK_SESSION_HANDLE session, CK_OBJECT_HANDLE key,
+                         CK_BYTE_PTR signature, CK_ULONG signature_length);
+
+int main(int argc, char **argv) {
+  CK_SESSION_HANDLE session1 = CK_INVALID_HANDLE;
+  CK_SESSION_HANDLE session2 = CK_INVALID_HANDLE;
+  CK_SESSION_HANDLE session3 = CK_INVALID_HANDLE;
+  struct pkcs_arguments args = {0};
+
+  if (get_pkcs_args(argc, argv, &args) < 0) {
+    return EXIT_FAILURE;
+  }
+
+  if (pkcs11_initialize(args.library) != CKR_OK) {
+    return EXIT_FAILURE;
+  }
+
+  open_sessions(&session1, &session2, &session3);
+
+  printf("session1: Logging in to slot via session1.\n");
+  CK_RV rv =
+      funcs->C_Login(session1, CKU_USER, args.pin, (CK_ULONG)strlen(args.pin));
+  if (rv != CKR_OK) {
+    fprintf(stderr, "session1: Failed to login.\n");
+    return rv;
+  }
+
+  printf("session1: Creating a session EC key pair that will share the "
+         "lifetime of session1.\n");
+  CK_OBJECT_HANDLE public_key = CK_INVALID_HANDLE;
+  CK_OBJECT_HANDLE private_key = CK_INVALID_HANDLE;
+  rv = generate_ec_keypair(session1, &public_key, &private_key);
+  if (CKR_OK != rv) {
+    fprintf(stderr, "session1: Failed to create ec key pair on session1.\n");
+    return rv;
+  }
+  printf("session1: EC key pair's public key handle id: %lu\n", public_key);
+  printf("session1: EC key pair's private key handle id: %lu\n\n", private_key);
+
+  printf("session2: Signing 'hello world' with session1's private on "
+         "session2: using key handle id: %lu\n",
+         private_key);
+  CK_BYTE signature[MAX_SIGNATURE_LENGTH];
+  CK_ULONG signature_length = MAX_SIGNATURE_LENGTH;
+  rv = sign_hello_world(session2, private_key, signature, &signature_length);
+  if (CKR_OK != rv) {
+    fprintf(stderr, "session2: Failed to sign.\n");
+    return rv;
+  }
+  printf("session2: Successfully signed 'hello world'.\n\n");
+
+  printf("session3: Verify signature on session3 with session1's public "
+         "key handle id: %lu\n",
+         public_key);
+  rv = verify_hello_world(session3, public_key, signature, signature_length);
+  if (CKR_OK != rv) {
+    fprintf(stderr, "session3: Failed to verify.\n");
+    return rv;
+  }
+  printf("session3: successfully verified.\n\n");
+
+  printf("session1: Closing session1.\n");
+  rv = funcs->C_CloseSession(session1);
+  if (CKR_OK != rv) {
+    printf("session1: Failed to close session1.\n");
+    return rv;
+  }
+  printf("session1: now that session1 is closed, the session key is now "
+         "destroyed.\n\n");
+
+  printf("session2: Trying to sign 'hello world' with session1's private key "
+         "handle id: "
+         "%lu\n",
+         private_key);
+  rv = sign_hello_world(session2, private_key, signature, &signature_length);
+  if (CKR_KEY_HANDLE_INVALID != rv) {
+    fprintf(stderr, "session2: Failed to get CKR_KEY_HANDLE_INVALID when "
+                    "signing with session 1's session key.\n");
+    return rv;
+  } else {
+    printf("session2: Failed to sign with session 1's session key "
+           "because the key handle was invalid after session 1 was closed.\n");
+  }
+}
+
+CK_RV open_sessions(CK_SESSION_HANDLE *const session1,
+                    CK_SESSION_HANDLE *const session2,
+                    CK_SESSION_HANDLE *const session3) {
+  // get the slot id to open a session on
+  CK_SLOT_ID slot_id;
+  CK_RV rv = pkcs11_get_slot(&slot_id);
+  if (rv != CKR_OK) {
+    fprintf(stderr, "Failed to get first slot.\n");
+    return rv;
+  }
+
+  // session 1
+  rv = funcs->C_OpenSession(slot_id, CKF_SERIAL_SESSION | CKF_RW_SESSION, NULL,
+                            NULL, session1);
+  if (rv != CKR_OK) {
+    fprintf(stderr, "Failed to open session1.\n");
+    return rv;
+  }
+
+  // session 2
+  rv = funcs->C_OpenSession(slot_id, CKF_SERIAL_SESSION | CKF_RW_SESSION, NULL,
+                            NULL, session2);
+  if (rv != CKR_OK) {
+    fprintf(stderr, "Failed to open session2.\n");
+    return rv;
+  }
+
+  // session 3
+  rv = funcs->C_OpenSession(slot_id, CKF_SERIAL_SESSION | CKF_RW_SESSION, NULL,
+                            NULL, session3);
+  if (rv != CKR_OK) {
+    fprintf(stderr, "Failed to open session3.\n");
+    return rv;
+  }
+
+  return CKR_OK;
+}
+
+// To learn more about key generation, please see the generate examples.
+CK_RV generate_ec_keypair(CK_SESSION_HANDLE session,
+                          CK_OBJECT_HANDLE_PTR public_key,
+                          CK_OBJECT_HANDLE_PTR private_key) {
+  CK_MECHANISM mech = {CKM_EC_KEY_PAIR_GEN, NULL, 0};
+  CK_BYTE prime256v1[] = {0x06, 0x08, 0x2a, 0x86, 0x48,
+                          0xce, 0x3d, 0x03, 0x01, 0x07};
+
+  CK_ATTRIBUTE public_key_template[] = {
+      {CKA_VERIFY, &true_val, sizeof(CK_BBOOL)},
+      {CKA_EC_PARAMS, prime256v1, sizeof(prime256v1)},
+      {CKA_TOKEN, &false_val, sizeof(CK_BBOOL)},
+  };
+
+  CK_ATTRIBUTE private_key_template[] = {
+      {CKA_SIGN, &true_val, sizeof(CK_BBOOL)},
+      {CKA_TOKEN, &false_val, sizeof(CK_BBOOL)},
+      {CKA_DERIVE, &true_val, sizeof(CK_BBOOL)},
+  };
+
+  CK_RV rv = funcs->C_GenerateKeyPair(
+      session, &mech, public_key_template,
+      sizeof(public_key_template) / sizeof(CK_ATTRIBUTE), private_key_template,
+      sizeof(private_key_template) / sizeof(CK_ATTRIBUTE), public_key,
+      private_key);
+  return rv;
+}
+
+// To learn more about sign/verify, please see the sign examples.
+CK_RV sign_hello_world(CK_SESSION_HANDLE session, CK_OBJECT_HANDLE key,
+                       CK_BYTE *const signature,
+                       CK_ULONG_PTR signature_length) {
+  CK_MECHANISM mech;
+  CK_BYTE_PTR data = "hello world";
+  CK_ULONG data_length = (CK_ULONG)strlen(data);
+
+  mech.mechanism = CKM_ECDSA_SHA512;
+  mech.ulParameterLen = 0;
+  mech.pParameter = NULL;
+
+  CK_RV rv = funcs->C_SignInit(session, &mech, key);
+  if (CKR_OK != rv) {
+    return rv;
+  }
+
+  rv = funcs->C_Sign(session, data, data_length, signature, signature_length);
+  return rv;
+}
+
+// To learn more about sign/verify, please see the sign examples.
+CK_RV verify_hello_world(CK_SESSION_HANDLE session, CK_OBJECT_HANDLE key,
+                         CK_BYTE_PTR signature, CK_ULONG signature_length) {
+  CK_MECHANISM mech;
+  CK_BYTE_PTR data = "hello world";
+  CK_ULONG data_length = (CK_ULONG)strlen(data);
+
+  mech.mechanism = CKM_ECDSA_SHA512;
+  mech.ulParameterLen = 0;
+  mech.pParameter = NULL;
+
+  CK_RV rv = funcs->C_VerifyInit(session, &mech, key);
+  if (CKR_OK != rv) {
+    return rv;
+  }
+
+  rv = funcs->C_Verify(session, data, data_length, signature, signature_length);
+  return rv;
+}


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

Small fix for aes_cbc on Windows.
Formatted via `clang-format -i src/session/*.c`

Tested on Windows and Linux

login_state:

```
Got the first slot which corresponds to your CloudHSM cluster, slot id = 2305843009213693953
Opening three sessions on the first slot.
Opened session1 on slot 2305843009213693953
Opened session2 on slot 2305843009213693953
Opened session3 on slot 2305843009213693953

Slot state: Connected to cluster: Not logged in
  * session1: Connected to cluster: Not logged in
  * session2: Connected to cluster: Not logged in
  * session3: Connected to cluster: Not logged in

Calling C_Login(session1, CU, pin, pin_length) on session 1 to authenticate the slot.
Successfully logged in to the slot via session1.
All sessions on the slot should now be authenticated with the single C_Login call,

Slot state: Connected to cluster: Authenticated
  * session1: Connected to cluster: Authenticated
  * session2: Connected to cluster: Authenticated
  * session3: Connected to cluster: Authenticated

Calling C_Login(session2, CU, pin, pin_length) on session 2 to authenticate the slot.
Expected: Failed to log in on session2 because the slot is already logged in.

Slot state: Connected to cluster: Authenticated
  * session1: Connected to cluster: Authenticated
  * session2: Connected to cluster: Authenticated
  * session3: Connected to cluster: Authenticated

Closing session1 via C_CloseSession(session1).
Even with session1 closed, we still expect session2 and session3 to be logged into the slot.

Slot state: Connected to cluster: Authenticated
  * session1: Disconnected from cluster
  * session2: Connected to cluster: Authenticated
  * session3: Connected to cluster: Authenticated

Calling C_Logout(session2) to log out of the slot.
Now we expect all open sessions on the slot to be logged out.

Slot state: Connected to cluster: Not logged in
  * session1: Disconnected from cluster
  * session2: Connected to cluster: Not logged in
  * session3: Connected to cluster: Not logged in
```

session_keys:

```
session1: Logging in to slot via session1.
session1: Creating a session EC key pair that will share the lifetime of session1.
session1: EC key pair's public key handle id: 4611686018427387905
session1: EC key pair's private key handle id: 4611686018427387906

session2: Signing 'hello world' with session1's private on session2: using key handle id: 4611686018427387906
session2: Successfully signed 'hello world'.

session3: Verify signature on session3 with session1's public key handle id: 4611686018427387905
session3: successfully verified.

session1: Closing session1.
session1: now that session1 is closed, the session key is now destroyed.

session2: Trying to sign 'hello world' with session1's private key handle id: 4611686018427387906
session2: Failed to sign with session 1's session key because the key handle was invalid after session 1 was closed.
```


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
