### PR TITLE
add public sample for aes cmac kdf

### DIFF
--- a/include/pkcs11/v2.40/cloudhsm_pkcs11_vendor_defs.h
+++ b/include/pkcs11/v2.40/cloudhsm_pkcs11_vendor_defs.h
@@ -1,6 +1,6 @@
 /*
  * Copyright (c) 2017, Cavium, Inc. All rights reserved.
- * 
+ *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are met:
  * 1. Redistributions of source code must retain the above copyright
@@ -11,7 +11,7 @@
  * 3. Neither the name of the Cavium, Inc. nor the
  *    names of its contributors may be used to endorse or promote products
  *    derived from this software without specific prior written permission.
- * 
+ *
  * THIS SOFTWARE IS PROVIDED BY CAVIUM INC. ''AS IS'' AND ANY
  * EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
  * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
@@ -25,25 +25,24 @@
  *
  */
 
-#ifndef _CLOUDHSM_PKCS11_VENDOR_DEFS_H_
-#define _CLOUDHSM_PKCS11_VENDOR_DEFS_H_
-
 #include "pkcs11.h"
 
 #ifdef _WIN32
 #pragma pack(push, cloudhsm_pkcs11_vendor_defines, 1)
 #endif
 
-#define CKM_DES3_NIST_WRAP             (CKM_VENDOR_DEFINED | 0x00008000UL)
+#ifndef CKM_CLOUDHSM_AES_GCM
 #define CKM_CLOUDHSM_AES_GCM           (CKM_VENDOR_DEFINED | CKM_AES_GCM)
+#endif
 
-// More information can be found at https://docs.aws.amazon.com/cloudhsm/latest/userguide/manage-aes-key-wrapping.html
-#define CKM_CLOUDHSM_AES_KEY_WRAP_NO_PAD        (CKM_VENDOR_DEFINED | CKM_AES_KEY_WRAP)
-#define CKM_CLOUDHSM_AES_KEY_WRAP_PKCS5_PAD     (CKM_VENDOR_DEFINED | CKM_AES_KEY_WRAP_PAD)
-#define CKM_CLOUDHSM_AES_KEY_WRAP_ZERO_PAD     (CKM_VENDOR_DEFINED | 0x0000216FUL)
+#ifndef CKM_SP800_108_COUNTER_KDF
 
-/* HMAC KDF Mechanism */
+/*
+HMAC/CMAC KDF Mechanism. The mechanism CKM_SP800_108_COUNTER_KDF is deprecated.
+The recommended mechanism for KDF is CKM_CLOUDHSM_SP800_108_COUNTER_KDF.
+*/
 #define CKM_SP800_108_COUNTER_KDF      (CKM_VENDOR_DEFINED | 0x00000001UL)
+#define CKM_CLOUDHSM_SP800_108_COUNTER_KDF (CKM_VENDOR_DEFINED | 0x00000001UL)
 
 typedef struct CK_SP800_108_COUNTER_FORMAT {
     CK_ULONG   ulWidthInBits;
@@ -63,11 +62,14 @@ typedef CK_SP800_108_DKM_LENGTH_FORMAT CK_PTR CK_SP800_108_DKM_LENGTH_FORMAT_PTR
 
 typedef CK_ULONG CK_PRF_DATA_TYPE;
 /* PRF data types */
-#define SP800_108_COUNTER_FORMAT       0x0004
-#define SP800_108_PRF_LABEL            0x0005
-#define SP800_108_PRF_CONTEXT          0x0006
-#define SP800_108_DKM_FORMAT           0x0007
-#define SP800_108_BYTE_ARRAY           0x0008
+#define CK_SP800_108_ITERATION_VARIABLE 0x0001
+#define CK_SP800_108_DKM_LENGTH         0x0002
+#define CK_SP800_108_BYTE_ARRAY         0x0003
+#define SP800_108_COUNTER_FORMAT        0x0004
+#define SP800_108_PRF_LABEL             0x0005
+#define SP800_108_PRF_CONTEXT           0x0006
+#define SP800_108_DKM_FORMAT            0x0007
+#define SP800_108_BYTE_ARRAY            0x0008
 
 typedef CK_MECHANISM_TYPE CK_PRF_TYPE;
 
@@ -90,7 +92,7 @@ typedef struct CK_SP800_108_KDF_PARAMS {
  * HMAC KDF mechanism (CKM_SP800_108_COUNTER_KDF).
  * prftype can be one of CKM_SHA_1_HMAC / SHA224_HMAC / SHA256_HMAC /
  * SHA384_HMAC / SHA512_HMAC.
- * Corrsponding to the mechanism, data has to be sent. This data will be stored
+ * Corresponding to the mechanism, data has to be sent. This data will be stored
  * in a buffer pointed to by pDataParams. Each data param will be of tlv form
  * For eg. if we are using counter kdf mechanism (CKM_SP800_108_COUNTER_KDF),
  * we have to send counter format, prf label, prf context and dkm format in
@@ -100,8 +102,20 @@ typedef struct CK_SP800_108_KDF_PARAMS {
  * and so on.
  */
 
+#endif // CKM_SP800_108_COUNTER_KDF
+
+#ifndef CKM_CLOUDHSM_AES_KEY_WRAP_NO_PAD
+#define CKM_CLOUDHSM_AES_KEY_WRAP_NO_PAD        (CKM_VENDOR_DEFINED | CKM_AES_KEY_WRAP)
+#endif
+
+#ifndef CKM_CLOUDHSM_AES_KEY_WRAP_PKCS5_PAD
+#define CKM_CLOUDHSM_AES_KEY_WRAP_PKCS5_PAD     (CKM_VENDOR_DEFINED | CKM_AES_KEY_WRAP_PAD)
+#endif
+
+#ifndef CKM_CLOUDHSM_AES_KEY_WRAP_ZERO_PAD
+#define CKM_CLOUDHSM_AES_KEY_WRAP_ZERO_PAD     (CKM_VENDOR_DEFINED | 0x0000216FUL)
+#endif
+
 #ifdef _WIN32
 #pragma pack(pop, cloudhsm_pkcs11_vendor_defines)
 #endif
-
-#endif /* _CLOUDHSM_PKCS11_VENDOR_DEFS_H_ */

--- a/src/derivation/CMakeLists.txt
+++ b/src/derivation/CMakeLists.txt
@@ -5,9 +5,12 @@ find_library(cloudhsmpkcs11 STATIC)
 
 add_executable(ecdh ecdh.c)
 add_executable(hmac_kdf hmac_kdf.c)
+add_executable(aes_cmac_kdf aes_cmac_kdf.c)
 
 target_link_libraries(ecdh cloudhsmpkcs11)
 target_link_libraries(hmac_kdf cloudhsmpkcs11)
+target_link_libraries(aes_cmac_kdf cloudhsmpkcs11)
 
 add_test(ecdh ecdh --pin ${HSM_USER}:${HSM_PASSWORD})
 add_test(hmac_kdf hmac_kdf --pin ${HSM_USER}:${HSM_PASSWORD})
+add_test(aes_cmac_kdf aes_cmac_kdf --pin ${HSM_USER}:${HSM_PASSWORD})

--- a/src/derivation/aes_cmac_kdf.c
+++ b/src/derivation/aes_cmac_kdf.c
@@ -1,0 +1,205 @@
+/*
+ * Copyright 2023 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of this
+ * software and associated documentation files (the "Software"), to deal in the Software
+ * without restriction, including without limitation the rights to use, copy, modify,
+ * merge, publish, distribute, sublicense, and/or sell copies of the Software, and to
+ * permit persons to whom the Software is furnished to do so.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED,
+ * INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A
+ * PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT
+ * HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+ * OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
+ * SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+
+#include <stdio.h>
+#include <string.h>
+#include <stdlib.h>
+#include <inttypes.h>
+#include <stdint.h>
+
+#include "common.h"
+
+CK_RV aes_cmac_kdf_sample(CK_SESSION_HANDLE session) {
+
+    CK_RV rv;
+
+    /* CKM_CLOUDHSM_SP800_108_COUNTER_KDF is a vendor defined mechanism in CloudHSM.
+     * It implements key derivation using the Counter mode construction
+     * specified in Section 5.1 of NIST Special Publication 800-108 at
+     * https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-108r1.pdf.
+     */
+    
+    /* Generate the Key Derivation Key aka the base key. This key will be
+     * used as an input to the derivation function, along with other input data.
+     */
+    CK_OBJECT_HANDLE base_key;
+    CK_MECHANISM base_key_mech = {CKM_AES_KEY_GEN, NULL, 0};
+    CK_OBJECT_CLASS base_key_class = CKO_SECRET_KEY;
+    CK_KEY_TYPE base_key_type = CKK_AES;
+    CK_ULONG base_key_len = 32;
+
+    CK_ATTRIBUTE base_key_template[] = {
+        {CKA_CLASS,           &base_key_class,    sizeof(CK_OBJECT_CLASS)},
+        {CKA_KEY_TYPE,        &base_key_type,     sizeof(CK_KEY_TYPE)},
+        {CKA_VALUE_LEN,       &base_key_len,      sizeof(CKA_VALUE_LEN)},
+        {CKA_DERIVE,          &true_val,          sizeof(CK_BBOOL)},
+        {CKA_TOKEN,           &false_val,         sizeof(CK_BBOOL)}
+    };
+    rv = funcs->C_GenerateKey(session,
+                              &base_key_mech,
+                              base_key_template,
+                              sizeof(base_key_template) / sizeof(CK_ATTRIBUTE),
+                              &base_key);
+    if (CKR_OK != rv) {
+        printf("Failed to generate base key\n");
+        return rv;
+    }
+
+    printf("Generated base AES key of size 32 bytes. Handle: %lu\n", base_key);
+   
+    /*
+     * Create a template for the derived key.
+     * For more information about the type of keys which may be derived, take a look at
+     * https://docs.aws.amazon.com/cloudhsm/latest/userguide/pkcs11-key-types.html.
+     */
+    CK_OBJECT_HANDLE derived_key;
+    CK_OBJECT_CLASS derived_key_class = CKO_SECRET_KEY;
+    CK_KEY_TYPE derived_key_type = CKK_AES;
+    CK_ULONG derived_key_len = 32;
+
+    char * derived_key_label = "derived_aes_cmac_key";
+
+    CK_ATTRIBUTE derived_key_template[] = {
+        {CKA_CLASS,           &derived_key_class,        sizeof(CK_OBJECT_CLASS)},
+        {CKA_KEY_TYPE,        &derived_key_type,         sizeof(CK_KEY_TYPE)},
+        {CKA_VALUE_LEN,       &derived_key_len,          sizeof(CKA_VALUE_LEN)},
+        {CKA_LABEL,           derived_key_label,		 sizeof(derived_key_label)},
+        {CKA_TOKEN,           &false_val,                sizeof(CK_BBOOL)}
+    };
+
+    /* 
+     * The KDF uses a counter variable and a string of fixed data as inputs
+     * to a pseudo-random function.
+     */
+
+    /* 
+     * Input 1: Counter format
+     * Format of the iteration counter represented as a binary string.
+     * Only supported counter widths are 16 and 32
+     */
+    CK_SP800_108_COUNTER_FORMAT counter_format;
+    counter_format.ulWidthInBits = 32;
+
+    /* 
+     * Input 2: DKM format
+     * Format of the derived keying material. It has two fields -
+     *
+     * ulWidthInBits: Only supported DKM widths are 8, 16, 32 and 64
+     * dkmLengthMethod: Only supported method is SP800_108_DKM_LENGTH_SUM_OF_KEYS
+     */
+    CK_SP800_108_DKM_LENGTH_FORMAT dkm_format;
+    dkm_format.dkmLengthMethod = SP800_108_DKM_LENGTH_SUM_OF_KEYS;
+    dkm_format.ulWidthInBits = 32;
+
+    /*
+     * Input 3: encoded_input_data
+     * This data is represented as 2 arrays. One is called prefix and other one suffix.
+
+     * The prefix array will be prepended to the counter and the suffix array will be appended
+     * to the counter. The prefix and suffix arrays may include any combination of Label, Context,
+     * a concatenation of both, or an empty array. In this example, the Label is included in the
+     * prefix and the Context is included in the suffix.
+
+     * Label:
+     * The label is a string that identifies the purpose for the derived keying
+     * material. It is encoded as a binary string.
+     * For more information, refer to the NIST Special Publication 800-108.
+     * for example: CK_BYTE label[] = {0x1, 0xab, 0xe1}; has been used as encoded_input_data_prefix in this example.
+
+     * Context:
+     * The context is a binary string containing information related to the
+     * derived keying material.
+     * For more information, refer to the NIST Special Publication 800-108.
+     * for example: CK_BYTE context[] = {0xc, 0x09, 0x7e, 0x7}; has been used as encoded_input_data_suffix.
+     */
+
+    CK_BYTE encoded_input_data_prefix[] = {0x1, 0xab, 0xe1};
+    CK_BYTE encoded_input_data_suffix[] = {0xc, 0x09, 0x7e, 0x7};
+
+    /*
+    * When specifying the KDF parameters, the ordering of the inputs determine the derived key material.
+    * Different orders will result in a different derived key.
+    *
+    * In this example, we specify the ordering: Label (prefix), Counter, Context (suffix), followed by
+    * the DKM Length. It is important to maintain this order in any application that expects to derive
+    * this same key.
+    */
+    CK_PRF_DATA_PARAM kdf_data_params[] = {
+        {CK_SP800_108_BYTE_ARRAY,            &encoded_input_data_prefix,         sizeof(encoded_input_data_prefix)},
+        {CK_SP800_108_ITERATION_VARIABLE,    &counter_format,                    sizeof(CK_SP800_108_COUNTER_FORMAT)},
+        {CK_SP800_108_BYTE_ARRAY,            &encoded_input_data_suffix,         sizeof(encoded_input_data_suffix)},
+        {CK_SP800_108_DKM_LENGTH,            &dkm_format,                        sizeof(CK_SP800_108_DKM_LENGTH_FORMAT)}
+    };
+
+    CK_SP800_108_KDF_PARAMS kdf_params;    
+    kdf_params.prftype = CKM_AES_CMAC;
+    kdf_params.pDataParams = kdf_data_params;
+    kdf_params.ulNumberOfDataParams = 4;
+
+    /* Populate the derivation mechanism */       
+    CK_MECHANISM derive_mech = {CKM_CLOUDHSM_SP800_108_COUNTER_KDF /* CloudHSM defined KDF mechanism */,
+                                &kdf_params, 
+                                sizeof(CK_SP800_108_KDF_PARAMS)};
+ 
+    /* Perform the derivation operation */
+    rv = funcs->C_DeriveKey(session, 
+                            &derive_mech, 
+                            base_key, 
+                            derived_key_template, 
+                            sizeof(derived_key_template) / sizeof(CK_ATTRIBUTE), 
+                            &derived_key);
+    if (CKR_OK != rv) {
+        printf("Failed to derive key\n");
+        return rv;
+    }
+
+    printf("Derived AES key of size 32 bytes. Handle: %lu\n", derived_key);
+    return rv;
+}
+
+int main(int argc, char **argv) {
+    CK_RV rv;
+    CK_SESSION_HANDLE session;
+
+    struct pkcs_arguments args = {0};
+    if (get_pkcs_args(argc, argv, &args) < 0) {
+        return EXIT_FAILURE;
+    }
+
+    rv = pkcs11_initialize(args.library);
+    if (CKR_OK != rv) {
+        printf("Pkcs11 initialization failed: %lu\n", rv);
+        return EXIT_FAILURE;
+    }
+
+    rv = pkcs11_open_session(args.pin, &session);
+    if (CKR_OK != rv) {
+        printf("Pkcs11 session open failed: %lu\n", rv);
+        return EXIT_FAILURE;
+    }
+
+    printf("Key derivation using AES CMAC KDF in Counter mode. Defined in NIST SP 800-108.\n");
+    rv = aes_cmac_kdf_sample(session);
+    if (CKR_OK != rv) {
+        printf("AES CMAC KDF derivation failed: %lu\n", rv);
+        return EXIT_FAILURE;
+    }
+
+    pkcs11_finalize_session(session);
+
+    return 0;
+}

--- a/src/derivation/aes_cmac_kdf.c
+++ b/src/derivation/aes_cmac_kdf.c
@@ -77,7 +77,7 @@ CK_RV aes_cmac_kdf_sample(CK_SESSION_HANDLE session) {
         {CKA_CLASS,           &derived_key_class,        sizeof(CK_OBJECT_CLASS)},
         {CKA_KEY_TYPE,        &derived_key_type,         sizeof(CK_KEY_TYPE)},
         {CKA_VALUE_LEN,       &derived_key_len,          sizeof(CKA_VALUE_LEN)},
-        {CKA_LABEL,           derived_key_label,		 sizeof(derived_key_label)},
+        {CKA_LABEL,           derived_key_label,		 strlen(derived_key_label)},
         {CKA_TOKEN,           &false_val,                sizeof(CK_BBOOL)}
     };
 


### PR DESCRIPTION
Issue #, if available:

add public sample for the aes cmac kdf algorithm in pkcs11.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
