### PR TITLE
Update failing tests to pass with SDK5

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,12 +38,12 @@ following installed:
 
 Create a build directory and execute CMake. This will create a Makefile for the
 project. Run make to build the examples. Specifying HSM_USER, HSM_PASSWORD, and
-TRUSTED_WRAPPING_KEY_HANDLE are optional for source build, but required for tests.
+TRUSTED_WRAPPING_KEY_LABEL are optional for source build, but required for tests.
 
 ```
 mkdir build/
 cd build/
-cmake .. -DHSM_USER=<user> -DHSM_PASSWORD=<password> -DTRUSTED_WRAPPING_KEY_HANDLE=<trusted_key>
+cmake .. -DHSM_USER=<user> -DHSM_PASSWORD=<password> -DTRUSTED_WRAPPING_KEY_LABEL=<trusted_key>
 make
 ```
 
@@ -51,12 +51,12 @@ make
 
 Create a build directory and execute CMake. This will create a Makefile for the
 project. Run make to build the examples. Specifying HSM_USER, HSM_PASSWORD, and
-TRUSTED_WRAPPING_KEY_HANDLE are optional for source build, but required for tests.
+TRUSTED_WRAPPING_KEY_LABEL are optional for source build, but required for tests.
 
 ```
 mkdir build/
 cd build/
-cmake .. -DHSM_USER=<user> -DHSM_PASSWORD=<password> -DTRUSTED_WRAPPING_KEY_HANDLE=<trusted_key> -DCLOUDHSM_PKCS11_VENDOR_DEFS_PATH=<path_to_pkcs11_header_file>
+cmake .. -DHSM_USER=<user> -DHSM_PASSWORD=<password> -DTRUSTED_WRAPPING_KEY_LABEL=<trusted_key> -DCLOUDHSM_PKCS11_VENDOR_DEFS_PATH=<path_to_pkcs11_header_file>
 ```
 The CLOUDHSM_PKCS11_VENDOR_DEFS_PATH is an optional parameter containing the path to the directory which contains the 
 custom header file cloudhsm_pkcs11_vendor_defs.h.
@@ -73,6 +73,8 @@ the samples.
 Application binaries are in the `build/src/` directory. Applications will request
 a PIN on the command line. The CloudHSM PKCS#11 library will be used by default.
 In Linux, the binaries have no file type. In Windows, the binaries will end in `.exe`
+
+CloudHSM PKCS#11 SDK does not currently support ECDH derive key with KDF. To enable ECDH derive key without KDF, use the `configure-pkcs11 --enable-ecdh-without-kdf` command.
 
 #### Linux
 

--- a/src/common/common.c
+++ b/src/common/common.c
@@ -75,10 +75,7 @@ int get_pkcs_args(int argc, char** argv, struct pkcs_arguments* args) {
         args->library = DEFAULT_PKCS11_LIBRARY_PATH;
     }
 
-    args->wrapping_key_handle = CK_INVALID_HANDLE;
-    if (options[2].argument) {
-        args->wrapping_key_handle = strtoul(options[2].argument, NULL, 0);
-    }
+    args->wrapping_key_label = options[2].argument;
 
     args->object_handle = CK_INVALID_HANDLE;
     if (options[3].argument) {

--- a/src/common/common.h
+++ b/src/common/common.h
@@ -37,7 +37,7 @@ void pkcs11_finalize_session(CK_SESSION_HANDLE session);
 struct pkcs_arguments {
     char *pin;
     char *library;
-    CK_OBJECT_HANDLE wrapping_key_handle;
+    char *wrapping_key_label;
     CK_OBJECT_HANDLE object_handle;
 };
 

--- a/src/derivation/ecdh.c
+++ b/src/derivation/ecdh.c
@@ -88,11 +88,14 @@ CK_RV generate_ecdh_derive_key(CK_SESSION_HANDLE session,
        return rv;
     }
 
+    // CloudHSM PKCS#11 SDK does not currently support ECDH derive key with KDF.
+    // To enable ECDH derive key without KDF, use the `configure-pkcs11 --enable-ecdh-without-kdf` command.
+
     ec_point_size = point_template[0].ulValueLen;
     CK_KEY_TYPE keyType = CKK_AES;
     CK_OBJECT_CLASS keyClass = CKO_SECRET_KEY;
     CK_ULONG aesKeyLen = 32;
-    CK_ECDH1_DERIVE_PARAMS params = { CKD_SHA256_KDF, 0, NULL, ec_point_size - 2, &ec_point_value[2] };
+    CK_ECDH1_DERIVE_PARAMS params = { CKD_NULL, 0, NULL, ec_point_size - 2, &ec_point_value[2] };
     CK_MECHANISM derive_mechanism = { CKM_ECDH1_DERIVE, &params, sizeof(params) };
 
     CK_ATTRIBUTE derivekey_template[] = {

--- a/src/wrapping/CMakeLists.txt
+++ b/src/wrapping/CMakeLists.txt
@@ -25,4 +25,4 @@ add_test(aes_zero_padding_wrapping aes_zero_padding_wrapping --pin ${HSM_USER}:$
 add_test(aes_wrapping aes_wrapping --pin ${HSM_USER}:${HSM_PASSWORD})
 add_test(rsa_wrapping rsa_wrapping --pin ${HSM_USER}:${HSM_PASSWORD}) 
 add_test(wrap_with_template wrap_with_template --pin ${HSM_USER}:${HSM_PASSWORD})
-add_test(unwrap_with_template unwrap_with_template --pin ${HSM_USER}:${HSM_PASSWORD} --wp_key ${TRUSTED_WRAPPING_KEY_HANDLE})
+add_test(unwrap_with_template unwrap_with_template --pin ${HSM_USER}:${HSM_PASSWORD} --wp_key ${TRUSTED_WRAPPING_KEY_LABEL})


### PR DESCRIPTION
*Description of changes:*
- Update ECDH and unwrap_with_template samples to work with SDK5
- Update README with appropriate changes

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
